### PR TITLE
Xu coast veg head fix

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -987,26 +987,27 @@ contains
 
                    ! This call will request that storage carbon will be transferred to 
                    ! leaf tissues. It is specified as a fraction of the available storage
-		   if(EDPftvarcon_inst%woody(ipft) == itrue) then
-                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, store_c_transfer_frac)
-                      currentCohort%laimemory = 0.0_r8		   
-		   else
-		   
+                  if(EDPftvarcon_inst%woody(ipft) == itrue) then
+
+                     call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, store_c_transfer_frac)
+                     currentCohort%laimemory = 0.0_r8		   
+
+                  else
+                  
                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-		               store_c_transfer_frac*currentCohort%laimemory/totalmemory)		   
+                     store_c_transfer_frac*currentCohort%laimemory/totalmemory)		   
 
                      call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
-		               store_c_transfer_frac*currentCohort%sapwmemory/totalmemory)
+                     store_c_transfer_frac*currentCohort%sapwmemory/totalmemory)
 
                      call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, & 
-		              store_c_transfer_frac*currentCohort%structmemory/totalmemory)
-			      
+                     store_c_transfer_frac*currentCohort%structmemory/totalmemory)
+               
                      currentCohort%laimemory = 0.0_r8
-		     currentCohort%structmemory = 0.0_r8
-		     currentCohort%sapwmemory = 0.0_r8
-		     
-		   endif		   
-
+                     currentCohort%structmemory = 0.0_r8
+                     currentCohort%sapwmemory = 0.0_r8
+                  
+                  endif		   
                 endif !pft phenology
              endif ! growing season 
 
@@ -1015,41 +1016,43 @@ contains
                  currentSite%cstatus == phen_cstat_iscold) then ! past leaf drop day? Leaves still on tree?  
 
                 if (currentCohort%status_coh == leaves_on) then ! leaves have not dropped
-		   ! leaf off occur on individuals bigger than specific size for grass
-                   if (currentCohort%dbh > EDPftvarcon_inst%phen_cold_size_threshold(ipft) &
-		       .or. EDPftvarcon_inst%woody(ipft)==itrue) then 
-                      ! This sets the cohort to the "leaves off" flag
-                      currentCohort%status_coh  = leaves_off
 
-                      ! Remember what the lai was (leaf mass actually) was for next year
-                      ! the same amount back on in the spring...
+		            ! leaf off occur on individuals bigger than specific size for grass
+                  if (currentCohort%dbh > EDPftvarcon_inst%phen_cold_size_threshold(ipft) &
+                  .or. EDPftvarcon_inst%woody(ipft)==itrue) then 
+                     
+                     ! This sets the cohort to the "leaves off" flag
+                     currentCohort%status_coh  = leaves_off
 
-                      currentCohort%laimemory   = leaf_c
+                     ! Remember what the lai was (leaf mass actually) was for next year
+                     ! the same amount back on in the spring...
 
-                      ! Drop Leaves (this routine will update the leaf state variables,
-                      ! for carbon and any other element that are prognostic. It will
-                      ! also track the turnover masses that will be sent to litter later on)
+                     currentCohort%laimemory   = leaf_c
 
-                      call PRTDeciduousTurnover(currentCohort%prt,ipft, &
-                           leaf_organ, leaf_drop_fraction)
-			 
-	              if(EDPftvarcon_inst%woody(ipft).ne.itrue)then
-			 
-                         currentCohort%sapwmemory   = sapw_c * stem_drop_fraction
-		   
-		         currentCohort%structmemory   = struct_c * stem_drop_fraction			 
+                     ! Drop Leaves (this routine will update the leaf state variables,
+                     ! for carbon and any other element that are prognostic. It will
+                     ! also track the turnover masses that will be sent to litter later on)
 
-                         call PRTDeciduousTurnover(currentCohort%prt,ipft, &
+                     call PRTDeciduousTurnover(currentCohort%prt,ipft, &
+                        leaf_organ, leaf_drop_fraction)
+         
+                     if(EDPftvarcon_inst%woody(ipft).ne.itrue)then
+               
+                           currentCohort%sapwmemory   = sapw_c * stem_drop_fraction
+               
+                           currentCohort%structmemory   = struct_c * stem_drop_fraction			 
+
+                           call PRTDeciduousTurnover(currentCohort%prt,ipft, &
                               sapw_organ, stem_drop_fraction)
 
-                         call PRTDeciduousTurnover(currentCohort%prt,ipft, &
+                           call PRTDeciduousTurnover(currentCohort%prt,ipft, &
                               struct_organ, stem_drop_fraction)
-	              endif	
-                    endif ! individual dbh size check
 
-                endif !leaf status
-             endif !currentSite status
-          endif  !season_decid
+                     endif	
+                  endif ! individual dbh size check
+               endif !leaf status
+            endif !currentSite status
+         endif  !season_decid
 
           ! DROUGHT LEAF ON
           ! Site level flag indicates it is no longer in drought condition
@@ -1057,98 +1060,101 @@ contains
 
           if (EDPftvarcon_inst%stress_decid(ipft) == itrue )then
              
-             if (currentSite%dstatus == phen_dstat_moiston .or. &
+            if (currentSite%dstatus == phen_dstat_moiston .or. &
                  currentSite%dstatus == phen_dstat_timeon )then 
 
-                ! we have just moved to leaves being on . 
-                if (currentCohort%status_coh == leaves_off)then    
+               ! we have just moved to leaves being on . 
+               if (currentCohort%status_coh == leaves_off)then    
 
                    !is it the leaf-on day? Are the leaves currently off?    
 
-                   currentCohort%status_coh = leaves_on    ! Leaves are on, so change status to 
+                  currentCohort%status_coh = leaves_on    ! Leaves are on, so change status to 
                                                            ! stop flow of carbon out of bstore. 
 
-                   if(store_c>nearzero) then
-                      store_c_transfer_frac = &
+                  if(store_c>nearzero) then
+
+                     store_c_transfer_frac = &
                             min(EDPftvarcon_inst%phenflush_fraction(ipft)*currentCohort%laimemory, store_c)/store_c
-	              if(EDPftvarcon_inst%woody(ipft).ne.itrue)then
-		         totalmemory=currentCohort%laimemory+currentCohort%sapwmemory+currentCohort%structmemory
-		         store_c_transfer_frac = min(EDPftvarcon_inst%phenflush_fraction(ipft)* &
-		                                 totalmemory, store_c)/store_c
-		      endif			    
-                   else
-                      store_c_transfer_frac = 0.0_r8
-                   end if
+
+                     if(EDPftvarcon_inst%woody(ipft).ne.itrue)then
+                     
+                     totalmemory=currentCohort%laimemory+currentCohort%sapwmemory+currentCohort%structmemory
+                     store_c_transfer_frac = min(EDPftvarcon_inst%phenflush_fraction(ipft)* &
+                                             totalmemory, store_c)/store_c
+
+                     endif
+
+                  else
+                     store_c_transfer_frac = 0.0_r8
+                  endif
                    
                    ! This call will request that storage carbon will be transferred to 
                    ! leaf tissues. It is specified as a fraction of the available storage
-		   if(EDPftvarcon_inst%woody(ipft) == itrue) then
-		   
-                      call PRTPhenologyFlush(currentCohort%prt, ipft, &
-                         leaf_organ, store_c_transfer_frac)
+                  if(EDPftvarcon_inst%woody(ipft) == itrue) then
+                  
+                     call PRTPhenologyFlush(currentCohort%prt, ipft, &
+                        leaf_organ, store_c_transfer_frac)
 
-                       currentCohort%laimemory = 0.0_r8
-	   
-		   else
-		   
+                     currentCohort%laimemory = 0.0_r8
+               
+                  else
+                  
                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-		               store_c_transfer_frac*currentCohort%laimemory/totalmemory)		   
+                     store_c_transfer_frac*currentCohort%laimemory/totalmemory)		   
 
                      call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
-		               store_c_transfer_frac*currentCohort%sapwmemory/totalmemory)
+                     store_c_transfer_frac*currentCohort%sapwmemory/totalmemory)
 
                      call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, & 
-		              store_c_transfer_frac*currentCohort%structmemory/totalmemory)
-			      
-		     currentCohort%laimemory = 0.0_r8
-		     currentCohort%structmemory = 0.0_r8
-		     currentCohort%sapwmemory = 0.0_r8
+                     store_c_transfer_frac*currentCohort%structmemory/totalmemory)
+                        
+                     currentCohort%laimemory = 0.0_r8
+                     currentCohort%structmemory = 0.0_r8
+                     currentCohort%sapwmemory = 0.0_r8
 		     
-		   endif
+		            endif
+               endif !currentCohort status again?
+            endif   !currentSite status
 
-                endif !currentCohort status again?
-             endif   !currentSite status
+            !DROUGHT LEAF OFF
+            if (currentSite%dstatus == phen_dstat_moistoff .or. &
+               currentSite%dstatus == phen_dstat_timeoff) then        
 
-             !DROUGHT LEAF OFF
-             if (currentSite%dstatus == phen_dstat_moistoff .or. &
-                 currentSite%dstatus == phen_dstat_timeoff) then        
+               if (currentCohort%status_coh == leaves_on) then ! leaves have not dropped
 
-                if (currentCohort%status_coh == leaves_on) then ! leaves have not dropped
-
-                   ! This sets the cohort to the "leaves off" flag
-                   currentCohort%status_coh      = leaves_off
-                   
-                   ! Remember what the lai (leaf mass actually) was for next year
-                   currentCohort%laimemory   = leaf_c
-		   
-                   call PRTDeciduousTurnover(currentCohort%prt,ipft, &
-                         leaf_organ, leaf_drop_fraction)
+                  ! This sets the cohort to the "leaves off" flag
+                  currentCohort%status_coh      = leaves_off
+                  
+                  ! Remember what the lai (leaf mass actually) was for next year
+                  currentCohort%laimemory   = leaf_c
+      
+                  call PRTDeciduousTurnover(currentCohort%prt,ipft, &
+                        leaf_organ, leaf_drop_fraction)
 			 
-	           if(EDPftvarcon_inst%woody(ipft).ne.itrue)then
-			 
-                      currentCohort%sapwmemory   = sapw_c * stem_drop_fraction
-		   
-		      currentCohort%structmemory   = struct_c * stem_drop_fraction			 
+                  if(EDPftvarcon_inst%woody(ipft).ne.itrue)then
+            
+                     currentCohort%sapwmemory   = sapw_c * stem_drop_fraction
+                     currentCohort%structmemory   = struct_c * stem_drop_fraction			 
 
-                      call PRTDeciduousTurnover(currentCohort%prt,ipft, &
-                         sapw_organ, stem_drop_fraction)
+                     call PRTDeciduousTurnover(currentCohort%prt,ipft, &
+                        sapw_organ, stem_drop_fraction)
 
-                      call PRTDeciduousTurnover(currentCohort%prt,ipft, &
-                         struct_organ, stem_drop_fraction)
-	           endif			 			 
+                     call PRTDeciduousTurnover(currentCohort%prt,ipft, &
+                        struct_organ, stem_drop_fraction)
+                  endif			 			 
 
-                endif
-             endif !status
-          endif !drought dec.
+               endif
+            endif !status
+         endif !drought dec.
 
-          if(debug) call currentCohort%prt%CheckMassConservation(ipft,1)
+         if(debug) call currentCohort%prt%CheckMassConservation(ipft,1)
 
-          currentCohort => currentCohort%shorter
-       enddo !currentCohort
+            currentCohort => currentCohort%shorter
+      enddo !currentCohort
 
-       currentPatch => currentPatch%younger
+      currentPatch => currentPatch%younger
 
-    enddo !currentPatch
+   enddo !currentPatch
 
   end subroutine phenology_leafonoff
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -510,14 +510,18 @@ contains
          temp_cohort%structmemory = c_struct * stem_drop_fraction
          c_leaf = 0._r8
          c_sapw = (1.0_r8-stem_drop_fraction) * c_sapw
-	      c_struct  = (1.0_r8-stem_drop_fraction) * c_struct
-	      cstatus = leaves_off
+         c_struct  = (1.0_r8-stem_drop_fraction) * c_struct
+         cstatus = leaves_off
        endif
 
        if ( EDPftvarcon_inst%stress_decid(pft) == itrue .and. &
             any(site_in%dstatus == [phen_dstat_timeoff,phen_dstat_moistoff])) then
           temp_cohort%laimemory = c_leaf
+          temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
+          temp_cohort%structmemory = c_struct * stem_drop_fraction
           c_leaf = 0._r8
+          c_sapw = (1.0_r8-stem_drop_fraction) * c_sapw
+          c_struct  = (1.0_r8-stem_drop_fraction) * c_struct
           cstatus = leaves_off
        endif
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -590,9 +590,9 @@ contains
        call prt_obj%CheckInitialConditions()
 
        call create_cohort(site_in, patch_in, pft, temp_cohort%n, temp_cohort%hite, &
-             temp_cohort%dbh, prt_obj, temp_cohort%laimemory, cstatus, rstatus, &
-             temp_cohort%sapwmemory,temp_cohort%structmemory, temp_cohort%canopy_trim, 1, & 
-             site_in%spread, bc_in)
+            temp_cohort%dbh, prt_obj, temp_cohort%laimemory, temp_cohort%sapwmemory, &
+            temp_cohort%structmemory, cstatus, rstatus, temp_cohort%canopy_trim, 1, &
+            site_in%spread, bc_in)
 
        deallocate(temp_cohort) ! get rid of temporary cohort
 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -245,11 +245,6 @@ module EDPftvarcon
      real(r8), allocatable :: phenflush_fraction(:)       ! Maximum fraction of storage carbon used to flush leaves
                                                           ! on bud-burst [kgC/kgC]
      real(r8), allocatable :: phen_cold_size_threshold(:) ! stem/leaf drop occurs on DBH size of decidious non-woody 
-                                                          !(coastal grass) plants larger than the threshold value 							  
-     real(r8), allocatable :: phen_stem_drop_fraction(:)  ! Fraction of stem dropped/senescened for decidious 
-                                                          ! non-woody (grass) plants						  
-
-     real(r8), allocatable :: phen_cold_size_threshold(:) ! stem/leaf drop occurs on DBH size of decidious non-woody 
                                                           ! (coastal grass) plants larger than the threshold value 							  
      real(r8), allocatable :: phen_stem_drop_fraction(:)  ! Fraction of stem dropped/senescened for decidious 
                                                           ! non-woody (grass) plants		

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1975,11 +1975,7 @@ contains
         write(fates_log(),fmt0) 'taul = ',EDPftvarcon_inst%taul 
         write(fates_log(),fmt0) 'taus = ',EDPftvarcon_inst%taus
         write(fates_log(),fmt0) 'phenflush_fraction',EDpftvarcon_inst%phenflush_fraction
-<<<<<<< HEAD
-	write(fates_log(),fmt0) 'phen_cold_size_threshold = ',EDPftvarcon_inst%phen_cold_size_threshold
-=======
         write(fates_log(),fmt0) 'phen_cold_size_threshold = ',EDPftvarcon_inst%phen_cold_size_threshold
->>>>>>> master
         write(fates_log(),fmt0) 'phen_stem_drop_fraction',EDpftvarcon_inst%phen_stem_drop_fraction
         write(fates_log(),fmt0) 'rootprof_beta = ',EDPftvarcon_inst%rootprof_beta
         write(fates_log(),fmt0) 'fire_alpha_SH = ',EDPftvarcon_inst%fire_alpha_SH
@@ -2200,11 +2196,6 @@ contains
            end if
            if ( ( EDPftvarcon_inst%phen_stem_drop_fraction(ipft) < 0.0_r8 ) .or. &
                 ( EDPFtvarcon_inst%phen_stem_drop_fraction(ipft) > 1 ) ) then
-<<<<<<< HEAD
-              
-=======
-
->>>>>>> master
               write(fates_log(),*) ' Deciduous non-wood plants must keep 0-100% of their stems'
               write(fates_log(),*) ' during the dedicous period.'
               write(fates_log(),*) ' PFT#: ',ipft
@@ -2212,11 +2203,7 @@ contains
               write(fates_log(),*) ' phen_stem_drop_fraction: ', EDPFtvarcon_inst%phen_stem_drop_fraction(ipft)
               write(fates_log(),*) ' Aborting'
               call endrun(msg=errMsg(sourcefile, __LINE__))
-<<<<<<< HEAD
-           end if	   
-=======
            end if	
->>>>>>> master
         end if
 
  

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -1045,22 +1045,22 @@ contains
          if( EDPftvarcon_inst%season_decid(temp_cohort%pft) == itrue .and. &
               any(csite%cstatus == [phen_cstat_nevercold,phen_cstat_iscold])) then
             temp_cohort%laimemory = b_leaf
-            temp_cohort%sapwmemory = b_sapwood * stem_drop_fraction
-            temp_cohort%structmemory = b_dead * stem_drop_fraction	    
+            temp_cohort%sapwmemory = b_sapw * stem_drop_fraction
+            temp_cohort%structmemory = b_struct * stem_drop_fraction	    
             b_leaf  = 0._r8
-	         b_sapwood = (1._r8 - stem_drop_fraction) * b_sapwood
-	         b_dead  = (1._r8 - stem_drop_fraction) * b_dead
+	         b_sapw = (1._r8 - stem_drop_fraction) * b_sapw
+	         b_struct  = (1._r8 - stem_drop_fraction) * b_struct
             cstatus = leaves_off
          endif
 
          if ( EDPftvarcon_inst%stress_decid(temp_cohort%pft) == itrue .and. &
               any(csite%dstatus == [phen_dstat_timeoff,phen_dstat_moistoff])) then
             temp_cohort%laimemory = b_leaf
-            temp_cohort%sapwmemory = b_sapwood * stem_drop_fraction
-            temp_cohort%structmemory = b_dead * stem_drop_fraction	    
+            temp_cohort%sapwmemory = b_sapw * stem_drop_fraction
+            temp_cohort%structmemory = b_struct * stem_drop_fraction	    
             b_leaf  = 0._r8
-	         b_sapwood = (1._r8 - stem_drop_fraction) * b_sapwood
-	         b_dead  = (1._r8 - stem_drop_fraction) * b_dead	    
+	         b_sapw = (1._r8 - stem_drop_fraction) * b_sapw
+	         b_struct  = (1._r8 - stem_drop_fraction) * b_struct	    
             cstatus = leaves_off
          endif
          

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -93,6 +93,8 @@ module FatesRestartInterfaceMod
   integer :: ir_g_sb_laweight_co
   integer :: ir_height_co
   integer :: ir_laimemory_co
+  integer :: ir_sapwmemory_co
+  integer :: ir_structmemory_co
   integer :: ir_nplant_co
   integer :: ir_gpp_acc_co
   integer :: ir_npp_acc_co
@@ -658,6 +660,16 @@ contains
          units='kgC/indiv', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_laimemory_co )
 
+    call this%set_restart_var(vname='fates_sapwmemory', vtype=cohort_r8, &
+         long_name='ed cohort - target sapwood biomass set from prev year', &
+         units='kgC/indiv', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_sapwmemory_co )
+    
+    call this%set_restart_var(vname='fates_structmemory', vtype=cohort_r8, &
+         long_name='ed cohort - target structural biomass set from prev year', &
+         units='kgC/indiv', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_structmemory_co )
+    
     call this%set_restart_var(vname='fates_nplant', vtype=cohort_r8, &
          long_name='ed cohort - number of plants in the cohort', &
          units='/patch', flushval = flushzero, &
@@ -1463,6 +1475,8 @@ contains
            rio_g_sb_laweight_co        => this%rvars(ir_g_sb_laweight_co)%r81d, &
            rio_height_co               => this%rvars(ir_height_co)%r81d, &
            rio_laimemory_co            => this%rvars(ir_laimemory_co)%r81d, &
+           rio_sapwmemory_co           => this%rvars(ir_sapwmemory_co)%r81d, &
+           rio_structmemory_co         => this%rvars(ir_structmemory_co)%r81d, &
            rio_nplant_co               => this%rvars(ir_nplant_co)%r81d, &
            rio_gpp_acc_co              => this%rvars(ir_gpp_acc_co)%r81d, &
            rio_npp_acc_co              => this%rvars(ir_npp_acc_co)%r81d, &
@@ -1663,6 +1677,8 @@ contains
                 rio_dbh_co(io_idx_co)          = ccohort%dbh
                 rio_height_co(io_idx_co)       = ccohort%hite
                 rio_laimemory_co(io_idx_co)    = ccohort%laimemory
+                rio_sapwmemory_co(io_idx_co)   = ccohort%sapwmemory
+                rio_structmemory_co(io_idx_co) = ccohort%structmemory
                 rio_g_sb_laweight_co(io_idx_co)= ccohort%g_sb_laweight
 
                 rio_nplant_co(io_idx_co)       = ccohort%n
@@ -2188,6 +2204,8 @@ contains
           rio_g_sb_laweight_co        => this%rvars(ir_g_sb_laweight_co)%r81d, &
           rio_height_co               => this%rvars(ir_height_co)%r81d, &
           rio_laimemory_co            => this%rvars(ir_laimemory_co)%r81d, &
+          rio_sapwmemory_co           => this%rvars(ir_sapwmemory_co)%r81d, &
+          rio_structmemory_co         => this%rvars(ir_structmemory_co)%r81d, &
           rio_nplant_co               => this%rvars(ir_nplant_co)%r81d, &
           rio_gpp_acc_co              => this%rvars(ir_gpp_acc_co)%r81d, &
           rio_npp_acc_co              => this%rvars(ir_npp_acc_co)%r81d, &
@@ -2351,6 +2369,8 @@ contains
                 ccohort%g_sb_laweight= rio_g_sb_laweight_co(io_idx_co)
                 ccohort%hite         = rio_height_co(io_idx_co)
                 ccohort%laimemory    = rio_laimemory_co(io_idx_co)
+                ccohort%sapwmemory   = rio_sapwmemory_co(io_idx_co)
+                ccohort%structmemory= rio_structmemory_co(io_idx_co)
                 ccohort%n            = rio_nplant_co(io_idx_co)
                 ccohort%gpp_acc      = rio_gpp_acc_co(io_idx_co)
                 ccohort%npp_acc      = rio_npp_acc_co(io_idx_co)

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -352,12 +352,6 @@ variables:
 	double fates_phen_stress_decid(fates_pft) ;
 		fates_phen_stress_decid:units = "logical flag" ;
 		fates_phen_stress_decid:long_name = "Binary flag for stress-deciduous leaf habit" ;
-	double fates_phen_cold_size_threshold(fates_pft) ;
-		fates_phen_cold_size_threshold:units = "cm" ;
-		fates_phen_cold_size_threshold:long_name = "the dbh size above which will lead to phenology-related stem and leaf drop" ;
-	double fates_phen_stem_drop_fraction(fates_pft) ;
-		fates_phen_stem_drop_fraction:units = "fraction" ;
-		fates_phen_stem_drop_fraction:long_name = "fraction of stems to drop for non-woody species during drought/cold" ;
 	double fates_phenflush_fraction(fates_pft) ;
 		fates_phenflush_fraction:units = "fraction" ;
 		fates_phenflush_fraction:long_name = "Upon bud-burst, the maximum fraction of storage carbon used for flushing leaves" ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -1022,10 +1022,6 @@ data:
  fates_phen_stem_drop_fraction = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
 
  fates_phen_stress_decid = 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1 ;
- 
- fates_phen_cold_size_threshold = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
- 
- fates_phen_stem_drop_fraction = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
 
  fates_phenflush_fraction = _, _, 0.5, _, 0.5, 0.5, _, 0.5, 0.5, 0.5, 0.5, 0.5 ;
 


### PR DESCRIPTION
Adding `sapwmemory` and `structmemory` to restart code and other small corrections

### Description:
This PR primarily adds the necessary variables to the FatesRestartInterfaceMod, the absence of which was discovered via the `ERS_D_Mmpi-serial_Ld5.1x1_brazil.I2000Clm50FatesCruGs` test set.  

This PR also includes a couple of errors that I accidentally injected into the code during a previous merge conflict, as well as some redundant lines that were merged and calls to the sapwood and structure that needed to be renamed based on a previous (unrelated PR) that were overlooked.
